### PR TITLE
Write tokens back to environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,6 +217,10 @@ function login(encryption) {
 								rej(e);
 							} else {
 								res(r.body);
+								process.env.IG_TOKENS_EXP = tokens.tokens_exp;
+								process.env.IG_XST = tokens['x-security-token'];
+								process.env.IG_CST = tokens.cst;
+								process.env.IG_LIGHTSTREAMER_END_POINT = tokens.lightstreamerEndpoint;								
 							}
 						});
 					}


### PR DESCRIPTION
Currently tokens are read from tokens.json and stored in environment variables when the node-ig-api modules is loaded. However, when these tokens are collected at login and written back to tokens.json they are not re-read until the module is re-loaded. I have added a few lines to write directly to the environment variables straight after writing to tokens.json.